### PR TITLE
Fix/opengl silicon

### DIFF
--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -1,0 +1,7 @@
+name: Run container in various way
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:

--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -1,7 +1,0 @@
-name: Run container in various way
-
-on:
-  pull_request:
-    branches: [ main ]
-
-jobs:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ defense:
 
 launch:
 	@docker build -t ${NAME}:on-built ./ && \
-		docker run -it --name=${NAME} --env="DISPLAY=host.docker.internal:0" --env="/.Xauthority" --net=host -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/.Xauthority ${OPTSINSTALL} ${NAME}:on-built
+		docker run -it --name=${NAME} --env="DISPLAY=host.docker.internal:0" --env="/.Xauthority" --platform=linux/amd64 --net=host -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/.Xauthority ${OPTSINSTALL} ${NAME}:on-built
 	
 run:
 	@/bin/bash -c "./configure.sh run"

--- a/README.md
+++ b/README.md
@@ -437,6 +437,9 @@ For getting the OpenGL Version you have been lucky to install:
 glxinfo | grep "OpenGL version"
 ```
 
+Interesting reading: [Archive OpenGL MACOSX](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_pg_concepts/opengl_pg_concepts.html#//apple_ref/doc/uid/TP40001987-CH208-SW1)  
+
+
 </details>
 
 <details id="exit"><summary><b>Exit container (all)</b></summary>

--- a/configure.sh
+++ b/configure.sh
@@ -145,7 +145,7 @@ if [ `uname ` = "Darwin" ];then
 		# Pour autoriser l'utilisation du GPU pour OpenGL -> checker si pas de
 		# soucis pour les autres users
 		printf "Your sudo password will be asked for X11 setup (it is not keeped)."
-		sudo defaults write org.xquartz.X11 enable_iglx -bool true
+		defaults write org.xquartz.X11 enable_iglx -bool true
 		printf "\n"
 		if [ $? -ne 0 ];then
 			printf "You need sudo rights for enabling org.xquartz.x11.\n"

--- a/configure.sh
+++ b/configure.sh
@@ -164,6 +164,8 @@ echo > "${OPTSFILE}"
 cat > ${DOCKERFILE} << EOF
 FROM --platform=linux/amd64 audeizreading/virtual-campus-42nice:latest
 
+RUN python3 -m pip install --upgrade norminette
+
 EOF
 
 install_optional_software "Firefox" "${OPTSFILE}" "apt -y update && apt upgrade -y && apt install -y firefox"
@@ -190,13 +192,13 @@ install_optional_software "Node.js" "${OPTSFILE}" "curl -fsSL https://deb.nodeso
 	&& echo \"deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main\" | tee /etc/apt/sources.list.d/yarn.list \\
 	&& apt-get update  && apt upgrade -y && apt-get install -y nodejs yarn;"
 
-isMxxMac
-if [ $? -eq 0 ]
-then
-install_optional_software "OpenGL" "${OPTSFILE}" "add-apt-repository -usy ppa:oibaf/graphics-drivers && apt-get install -y libxmu-dev libxi-dev libgl-dev glew-utils libglu1-mesa-dev freeglut3-dev mesa-common-dev mesa-utils libgl1-mesa-dri libgl1-mesa-glx libglu1-mesa libosmesa6-dev libosmesa6 mesa-va-drivers mesa-vulkan-drivers freeglut3 libglew-dev mesa-vdpau-drivers && echo \"export LIBGL_ALWAYS_INDIRECT=1\\nexport MESA_GL_VERSION_OVERRIDE=4.3\\n\" >> /etc/bash.bashrc"
-else
-	display_error "You cannot install OpenGL because of the incompatibily of the installation. I Hope it will be fixed soon!."
-fi
+#isMxxMac
+#if [ $? -eq 0 ]
+#then
+install_optional_software "OpenGL" "${OPTSFILE}" "apt -y install software-properties-common dirmngr apt-transport-https lsb-release ca-certificates && add-apt-repository -usy ppa:oibaf/graphics-drivers && apt-get install -y libxmu-dev libxi-dev libgl-dev glew-utils libglu1-mesa-dev freeglut3-dev mesa-common-dev mesa-utils libgl1-mesa-dri libgl1-mesa-glx libglu1-mesa libosmesa6-dev libosmesa6 mesa-va-drivers mesa-vulkan-drivers freeglut3 libglew-dev mesa-vdpau-drivers && echo \"export LIBGL_ALWAYS_INDIRECT=1\\nexport MESA_GL_VERSION_OVERRIDE=4.3\\n\" >> /etc/bash.bashrc"
+#else
+#	display_error "You cannot install OpenGL because of the incompatibily of the installation. I Hope it will be fixed soon!."
+#fi
 # Si ./configure.sh defense -> On lance un container pr defense = git clone
 # du repo vogsphere depuis host + copie du projet dans le container +
 # positionnement dans le repertoire de correction au demarrage du container

--- a/configure.sh
+++ b/configure.sh
@@ -192,13 +192,7 @@ install_optional_software "Node.js" "${OPTSFILE}" "curl -fsSL https://deb.nodeso
 	&& echo \"deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main\" | tee /etc/apt/sources.list.d/yarn.list \\
 	&& apt-get update  && apt upgrade -y && apt-get install -y nodejs yarn;"
 
-#isMxxMac
-#if [ $? -eq 0 ]
-#then
 install_optional_software "OpenGL" "${OPTSFILE}" "apt -y install software-properties-common dirmngr apt-transport-https lsb-release ca-certificates && add-apt-repository -usy ppa:oibaf/graphics-drivers && apt-get install -y libxmu-dev libxi-dev libgl-dev glew-utils libglu1-mesa-dev freeglut3-dev mesa-common-dev mesa-utils libgl1-mesa-dri libgl1-mesa-glx libglu1-mesa libosmesa6-dev libosmesa6 mesa-va-drivers mesa-vulkan-drivers freeglut3 libglew-dev mesa-vdpau-drivers && echo \"export LIBGL_ALWAYS_INDIRECT=1\\nexport MESA_GL_VERSION_OVERRIDE=4.3\\n\" >> /etc/bash.bashrc"
-#else
-#	display_error "You cannot install OpenGL because of the incompatibily of the installation. I Hope it will be fixed soon!."
-#fi
 # Si ./configure.sh defense -> On lance un container pr defense = git clone
 # du repo vogsphere depuis host + copie du projet dans le container +
 # positionnement dans le repertoire de correction au demarrage du container

--- a/configure.sh
+++ b/configure.sh
@@ -162,7 +162,7 @@ OPTSINSTALL=""
 
 echo > "${OPTSFILE}"
 cat > ${DOCKERFILE} << EOF
-FROM --platform=linux/amd64 audeizreading/virtual-campus-42nice:latest
+FROM audeizreading/virtual-campus-42nice:latest
 
 RUN python3 -m pip install --upgrade norminette
 


### PR DESCRIPTION
Fix:
`add-apt repository` certains env Linux ne le reconnaissent pas, donc install au prealable et ca fonctionne
`sudo` -> bah en fait ca ecrit pas les bonnes opts pour openGL donc on l'enleve
Norminette -> elle se mettra a jour a chq install du container
Ajout `--platform=linux/amd64` au run du container par securité

Normalement ca fonctionne
Testé sur un Mac Intel et un Mac M2 (Un grand merci à @louchebem06 )