### PR TITLE
pr nodejs19 -> nodejs 18 (version stable)

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -185,7 +185,7 @@ then
 	OPTSINSTALL="-v /var/run/docker.sock:/var/run/docker.sock "${OPTSINSTALL}
 fi
 
-install_optional_software "Node.js" "${OPTSFILE}" "curl -fsSL https://deb.nodesource.com/setup_19.x | bash - \\
+install_optional_software "Node.js" "${OPTSFILE}" "curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \\
 	&& curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \\
 	&& echo \"deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main\" | tee /etc/apt/sources.list.d/yarn.list \\
 	&& apt-get update  && apt upgrade -y && apt-get install -y nodejs yarn;"


### PR DESCRIPTION
retrograde node version 18 comme recommandé sur le site de node (la 19 ne fait pas partie des preconisee, et la 20 est pas encore stable)
Je pense qu'on aura encore les warning à l'install et je pense que c'est la facon que j'ai de l'installer qui trigger le warning (curl et non apt)